### PR TITLE
横スワイプを無効化する

### DIFF
--- a/app/src/main/java/jp/co/charco/praisesreminder/ui/praises/PraiseListFragment.kt
+++ b/app/src/main/java/jp/co/charco/praisesreminder/ui/praises/PraiseListFragment.kt
@@ -60,7 +60,7 @@ class PraiseListFragment : Fragment() {
 
     private val itemTouchHelper = ItemTouchHelper(object : ItemTouchHelper.SimpleCallback(
         ItemTouchHelper.UP or ItemTouchHelper.DOWN,
-        ItemTouchHelper.LEFT,
+        0,
     ) {
         override fun onMove(
             recyclerView: RecyclerView,
@@ -78,6 +78,7 @@ class PraiseListFragment : Fragment() {
         }
 
         override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) = Unit
+        override fun isItemViewSwipeEnabled(): Boolean = false
     })
 
     companion object {


### PR DESCRIPTION
#59 の対応

https://stackoverflow.com/questions/30713121/disable-swipe-for-position-in-recyclerview-using-itemtouchhelper-simplecallback
のベストアンサーが下のメソッドの実装であるが、
`isItemViewSwipeEnabled()` というメソッドがあったので、こちらを実装した 


```
override fun getSwipeDirs (recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder): Int {
    if (viewHolder is CartAdapter.MyViewHolder) return 0
    return super.getSwipeDirs(recyclerView, viewHolder)
}
```
