### PR TITLE
GitHub Actions で利用する JDK のバージョンを 11 に変更

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: set up JDK 1.8
+      - name: set up JDK 11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 11
       - name: copy google-service
         env:
           GOOGLE_SERVICES_JSON: ${{secrets.GOOLE_SERVICES_JSON_DEV}}


### PR DESCRIPTION
#69 の対応

## 原因
AGP 7 は JDK 11 が必要だが、GitHub Actions は JDK 1.8 のままであるため

## メモ
actions/setup-java にv2が追加されている、が今は移行せず
https://github.com/actions/setup-java/blob/main/README.md